### PR TITLE
FcrepoCloudMigrator::Metadata

### DIFF
--- a/lib/fcrepo_cloud_migrator.rb
+++ b/lib/fcrepo_cloud_migrator.rb
@@ -7,6 +7,10 @@ require 'fcrepo_cloud_migrator/logging'
 require 'fcrepo_cloud_migrator/metadata'
 require 'rdf/turtle'
 
+EBUCORE_FILENAME_PREDICATE      = RDF::URI('http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename')
+EBUCORE_MIMETYPE_PREDICATE      = RDF::URI('http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType')
+PREMIS_MESSAGE_DIGEST_PREDICATE = RDF::URI('http://www.loc.gov/premis/rdf/v1#hasMessageDigest')
+
 module FcrepoCloudMigrator
   def self.logger
     FcrepoCloudMigrator::Logging.logger

--- a/lib/fcrepo_cloud_migrator/binary.rb
+++ b/lib/fcrepo_cloud_migrator/binary.rb
@@ -6,9 +6,6 @@ module FcrepoCloudMigrator
   class Binary
     attr_reader :checksum, :file, :graph
 
-    EBUCORE_FILENAME_PREDICATE      = 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename'
-    PREMIS_MESSAGE_DIGEST_PREDICATE = 'http://www.loc.gov/premis/rdf/v1#hasMessageDigest'
-
     def initialize(file:, graph:)
       @file        = file
       @graph       = graph

--- a/lib/fcrepo_cloud_migrator/files.rb
+++ b/lib/fcrepo_cloud_migrator/files.rb
@@ -4,8 +4,6 @@ module FcrepoCloudMigrator
   class Files
     attr_reader :directory
 
-    EBUCORE_FILENAME_PREDICATE = 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename'
-
     def initialize(directory:)
       @directory = directory
     end

--- a/lib/fcrepo_cloud_migrator/metadata.rb
+++ b/lib/fcrepo_cloud_migrator/metadata.rb
@@ -2,14 +2,109 @@
 
 module FcrepoCloudMigrator
   class Metadata
-    EBUCORE_FILENAME_PREDICATE = 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename'
-    def initialize(file:)
-      @file = file
-      @graph = RDF::Graph.load(file, format: :ttl)
+    attr_reader   :binary, :bucket, :file
+    attr_accessor :graph
+
+    def initialize(bucket:, file:, binary:, graph:)
+      @bucket = bucket
+      @file   = file
+      @binary = binary
+      @graph  = graph
     end
 
-    # ebucore:locator and ebucore:filename to s3 location
+    def modified_graph
+      statement = new_filename_statement
 
-    # remove ebucore:hasMimeType
+      remove_filename
+      remove_mime_type
+      graph.send(:insert_statement, statement)
+      graph
+    end
+
+    def output
+      RDF::Turtle::Writer.buffer(prefixes: prefixes) do |writer|
+        modified_graph.each_statement do |statement|
+          writer << statement
+        end
+      end
+    end
+
+    private
+
+      def new_filename_statement
+        subject   = filename_subject
+        object    = "s3://#{binary.checksum_from_graph}"
+        predicate = EBUCORE_FILENAME_PREDICATE
+        RDF::Statement.new(subject, predicate, object)
+      end
+
+      def filename_subject
+        filename_query.first.subject
+      end
+
+      def remove_filename
+        filename_query.each do |statement|
+          graph.send(:delete_statement, statement)
+        end
+      end
+
+      def filename_query
+        graph.query(predicate: EBUCORE_FILENAME_PREDICATE)
+      end
+
+      def remove_mime_type
+        mimetype_query.each do |statement|
+          graph.send(:delete_statement, statement)
+        end
+      end
+
+      def mimetype_query
+        graph.query(predicate: EBUCORE_MIMETYPE_PREDICATE)
+      end
+
+      def prefixes # rubocop:disable Metrics/MethodLength
+        {
+          premis:       'http://www.loc.gov/premis/rdf/v1#',
+          nt:           'http://www.jcp.org/jcr/nt/1.0',
+          ns021:        'http://purl.org/spar/datacite/',
+          rdfs:         'http://www.w3.org/2000/01/rdf-schema#',
+          ns020:        'http://projecthydra.org/ns/auth/acl#',
+          ns004:        'http://id.loc.gov/vocabulary/relators/',
+          ns003:        'info:fedora/fedora-system:def/model#',
+          ns002:        'http://projecthydra.org/works/models#',
+          ns001:        'http://purl.org/dc/terms/',
+          xsi:          'http://www.w3.org/2001/XMLSchema-instance',
+          ns008:        'http://www.openarchives.org/ore/terms/',
+          mode:         'http://www.modeshape.org/1.0',
+          ns007:        'http://www.w3.org/ns/auth/acl#',
+          ns006:        'http://pcdm.org/models#',
+          ns005:        'http://scholarsphere.psu.edu/ns#',
+          xml:          'http://www.w3.org/XML/1998/namespace',
+          ns009:        'http://www.iana.org/assignments/relation/',
+          jcr:          'http://www.jcp.org/jcr/1.0',
+          fedoraconfig: 'http://fedora.info/definitions/v4/config#',
+          mix:          'http://www.jcp.org/jcr/mix/1.0',
+          foaf:         'http://xmlns.com/foaf/0.1/',
+          image:        'http://www.modeshape.org/images/1.0',
+          sv:           'http://www.jcp.org/jcr/sv/1.0',
+          test:         'info:fedora/test/',
+          ns011:        'http://www.w3.org/2003/12/exif/ns#',
+          ns010:        'http://pcdm.org/use#',
+          ns015:        'http://projecthydra.org/ns/mix/',
+          ns014:        'http://sweet.jpl.nasa.gov/2.2/reprDataFormat.owl#',
+          ns013:        'http://projecthydra.org/ns/fits/',
+          ns012:        'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+          ns019:        'http://projecthydra.org/ns/odf/',
+          ns018:        'http://fedora.info/definitions/1/0/access/ObjState#',
+          ns017:        'http://projecthydra.org/ns/audio/',
+          ns016:        'http://www.w3.org/2011/content#',
+          rdf:          'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+          fedora:       'http://fedora.info/definitions/v4/repository#',
+          ebucore:      'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
+          ldp:          'http://www.w3.org/ns/ldp#',
+          xs:           'http://www.w3.org/2001/XMLSchema',
+          dc:           'http://purl.org/dc/elements/1.1/'
+        }
+      end
   end
 end

--- a/spec/fcrepo_cloud_migrator/metadata_spec.rb
+++ b/spec/fcrepo_cloud_migrator/metadata_spec.rb
@@ -1,6 +1,39 @@
 # frozen_string_literal: true
 
 RSpec.describe FcrepoCloudMigrator::Metadata do
-  xit 'does something' do
+  let(:bucket)   { 'test-bucket' }
+  let(:binary)   { FcrepoCloudMigrator::Binary.new(file: file, graph: graph) }
+  let(:file)     { 'spec/fixtures/data/01/3r074v01q/files/84df4a72-1149-4438-874d-495aef0d84ca/fcr%3Ametadata.ttl' }
+  let(:graph)    { RDF::Graph.load(file, format: :ttl) }
+  let(:metadata) { described_class.new(bucket: bucket, file: file, binary: binary, graph: graph) }
+
+  describe '.modified_graph' do
+    it 'modifies the ebucore#filename statement' do
+      expect(ebucore_filename_object(metadata.modified_graph)).to eq 's3://7dc9ca05fd6ae49afde0bc3fa65ae5a6b66b539e'
+    end
+
+    it 'removes the ebucore#hasMimeType statement' do
+      expect(has_mimetype?(metadata.modified_graph)).to be_falsey
+    end
+  end
+
+  describe '.output' do
+    it 'serializes turtle with the correct statements' do
+      # this assertion should be checking for (graph.count - 1)
+      # due to the ebcore#hasMimeType statement removal, but there is
+      # a duplicate statement ("a ldp:NonRDFSource ;") in the
+      # fcrepo-import-tool that is not duplicated in RDF::Turtle::Writer
+      expect(RDF::Reader.for(:turtle).new(metadata.output).triples.count)
+        .to eq graph.count
+    end
+  end
+
+  def ebucore_filename_object(graph)
+    filename_statements = graph.query(predicate: RDF::URI(EBUCORE_FILENAME_PREDICATE))
+    filename_statements.first.object.to_s
+  end
+
+  def has_mimetype?(graph)
+    graph.query(predicate: RDF::URI(EBUCORE_MIMETYPE_PREDICATE)).any?
   end
 end


### PR DESCRIPTION
- Implement FcrepoCloudMigrator::Metadata functionality
- Use RDF::Turtle::Writer.buffer and add prefix to FcrepoCloudMigrator.update_file output
- Add FcrepoCloudMigrator::Metadata specs
- Refactor constants for better re-use